### PR TITLE
Switch to lts and mainstream happy, add NixOS installation instructions

### DIFF
--- a/install.md
+++ b/install.md
@@ -31,6 +31,12 @@ cd buildsome
 stack install
 ```
 
+On NixOS use the following command:
+
+```
+nix-shell -p stack --run 'stack install --nix-packages leveldb'
+```
+
 ## `$PATH` variable
 
 Stack installs buildsome at `$HOME/.local/bin`, so make sure

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,10 +2,8 @@ flags:
   buildsome:
     Charts: False
 packages:
-- location: https://github.com/da-x/happy/archive/65c2494c77bd1bb321c1eb29b5117a975b1723a0.zip
-  extra-dep: true
 - .
 extra-deps:
 - leveldb-haskell-0.6.3
-resolver: nightly-2018-06-14
+resolver: lts-12.26
 rebuild-ghc-options: true


### PR DESCRIPTION
I had some troubles with installing Buildsome on NixOS, and fixed it by using lts stack and mainstream happy.

* Commits from https://github.com/da-x/happy is already merged into mainstream happy, so there is no reason to depend on the patched happy. (fixes #84 for me)
* Nightly stack resolver requirement was introduced in 556f5c8645dd8a00db6ffb1e8a009e19227a4b09. Now, lts with ghc 8.4 is available, so we can switch on it.

Also, added installation instructions for NixOS.