### PR TITLE
packaging: adaption to RockyLinux 8.5

### DIFF
--- a/packaging/build-srpm
+++ b/packaging/build-srpm
@@ -87,7 +87,8 @@ if [[ "${MOCK_CONFIG}" != "" ]] ; then
         MOCK_ARGS=""
     fi
     MOCK_ARGS="${MOCK_ARGS}"
-    sudo mock \
+    mock \
+	--dnf \
         --resultdir=${TARGET_DIR}/RESULT \
         ${MOCK_ARGS} ${TARGET_DIR}/SRPMS/*.src.rpm ||
        (cat ${TARGET_DIR}/RESULT/build.log && exit 1)

--- a/packaging/buildsome.spec
+++ b/packaging/buildsome.spec
@@ -15,11 +15,24 @@ BuildRoot:      %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 # This can be rectified in the future.
 BuildRequires:  leveldb-devel
 BuildRequires:  snappy-devel
-#BuildRequires: happy
 BuildRequires:  gmp-devel
-BuildRequires:  python
+BuildRequires:  python3
+BuildRequires:  python2
 BuildRequires:  chrpath
 BuildRequires:  wget
+BuildRequires:  perl
+BuildRequires:  make
+BuildRequires:  automake
+BuildRequires:  gcc
+BuildRequires:  gmp-devel
+BuildRequires:  libffi
+BuildRequires:  zlib
+BuildRequires:  zlib-devel
+BuildRequires:  xz
+BuildRequires:  tar
+BuildRequires:  git
+BuildRequires:  gnupg
+BuildRequires:  ncurses-libs
 
 %if 0%{?fedora} >= 24
 # GHC builds need tinfo.so.5
@@ -39,27 +52,35 @@ declaration of the build steps, and give better guarantees to users.
 %setup -q
 
 mkdir -p ~/.local/{bin,stack}
-export PATH=~/.local/bin:$PATH
+export PATH=~/.local/bin:$PATH:/tmp
+export LD_LIBRARY_PATH=/tmp/lib:$LD_LIBRARY_PATH
+mkdir /tmp/lib
+ln -s /usr/lib64/libncursesw.so.6 /tmp/lib/libncursesw.so.5
+cd /tmp
+wget http://archive.ubuntu.com/ubuntu/pool/main/g/gmp/gmp_6.1.2+dfsg.orig.tar.xz
+tar xf gmp_6.1.2+dfsg.orig.tar.xz
+cd gmp-6.1.2+dfsg
+./configure  --prefix=/tmp
+make install
+ln -s /tmp/lib/libgmp.so.10 /tmp/lib/libgmp.so.3
+cd /tmp
+wget https://downloads.haskell.org/~ghc/7.0.1/ghc-7.0.1-x86_64-unknown-linux.tar.bz2
+tar xf ghc-7.0.1-x86_64-unknown-linux.tar.bz2
+cd ghc-7.0.1
+./configure --prefix=/tmp
+make install
+cd /tmp
+curl -sSL https://get.haskellstack.org/ -o haskellstack.sh
+bash ./haskellstack.sh -d /tmp
+stack install alex happy
 
-if [[ ! -x ~/.local/bin/stack ]] ; then
-    wget https://github.com/commercialhaskell/stack/releases/download/v1.9.3/stack-1.9.3-linux-x86_64.tar.gz
-    tar -zxf stack-1.9.3-linux-x86_64.tar.gz -C ~/.local/stack
-    ln -f -s ~/.local/stack/stack-1.9.3-linux-x86_64/stack ~/.local/bin/stack
-fi
-
-stack --no-terminal setup
-
-pushd ~
-# A hack to make sure *some* version of Happy is installed before proceeding
-stack --resolver lts-6.35 --no-terminal setup
-stack --resolver lts-6.35 install happy
-popd
 
 %build
 
 # It depends on git, we need to fix that. For now:
 export BUILDSOME_BUILT_REVISION=%{version}-%{release}
-export PATH=~/.local/bin:$PATH
+export PATH=~/.local/bin:$PATH:/tmp
+export LD_LIBRARY_PATH=/tmp/lib:$LD_LIBRARY_PATH
 
 # Proceed to build Buildsome
 stack --no-terminal build
@@ -69,26 +90,26 @@ stack --no-terminal build
 echo rpm build root: $RPM_BUILD_ROOT
 echo prefix is: %{_prefix}
 
-mkdir -p $RPM_BUILD_ROOT/%{_prefix}/share/doc/buildsome-0.1.0.0
-cp LICENSE.txt $RPM_BUILD_ROOT/%{_prefix}/share/doc/buildsome-0.1.0.0/LICENSE.txt
+mkdir -p $RPM_BUILD_ROOT/%{_prefix}/share/doc/buildsome-0.1.1.0
+cp LICENSE.txt $RPM_BUILD_ROOT/%{_prefix}/share/doc/buildsome-0.1.1.0/LICENSE.txt
 
-mkdir -p $RPM_BUILD_ROOT/%{_prefix}/share/buildsome-0.1.0.0/cbits
-cp .stack-work/*/*/*/*/*/*/*/cbits/fs_override.so $RPM_BUILD_ROOT/%{_prefix}/share/buildsome-0.1.0.0/cbits
+mkdir -p $RPM_BUILD_ROOT/%{_prefix}/share/buildsome-0.1.1.0/cbits
+cp .stack-work/*/*/*/*/*/*/*/cbits/fs_override.so $RPM_BUILD_ROOT/%{_prefix}/share/buildsome-0.1.1.0/cbits
 
 mkdir -p $RPM_BUILD_ROOT/%{_prefix}/bin
 buildsome_exe=$RPM_BUILD_ROOT/%{_prefix}/bin/buildsome
 cp .stack-work/install/*/*/*/bin/buildsome ${buildsome_exe}
 
-abs_share_path=$(ls -1d `pwd`/.stack-work/*/*/*/*/*/*/buildsome-0.1.0.0)
+abs_share_path=$(ls -1d `pwd`/.stack-work/*/*/*/*/*/*/buildsome-0.1.1.0)
 
 # Patch executable to point to the correct path of fs_override.so (how are
 # you supposed to do this with Stack? Did not find in docs.
 
-python -c """
+python2 -c """
 f = \"${buildsome_exe}\"
 content = open(f).read()
 a = \"${abs_share_path}\"
-b = \"%{_prefix}/share/buildsome-0.1.0.0\"
+b = \"%{_prefix}/share/buildsome-0.1.1.0\"
 b += \"\0\" * (len(a) - len(b))
 content = content.replace(a, b)
 open(f, \"w\").write(content)
@@ -102,7 +123,7 @@ chrpath -d ${buildsome_exe}
 %files
 %{_prefix}/bin/buildsome
 # FIXME: Version needs to be automated here.
-%{_prefix}/share/buildsome-0.1.0.0/cbits/fs_override.so
-%{_prefix}/share/doc/buildsome-0.1.0.0/LICENSE.txt
+%{_prefix}/share/buildsome-0.1.1.0/cbits/fs_override.so
+%{_prefix}/share/doc/buildsome-0.1.1.0/LICENSE.txt
 
 %changelog


### PR DESCRIPTION
the head of /etc/mock/elastifile-rocky-x86_64.cfg

config_opts['root'] = 'elastifile-rocky-x86_64'
config_opts['target_arch'] = 'x86_64'
config_opts['legal_host_arches'] = ('x86_64',)
config_opts['chroot_setup_cmd'] = 'install tar gcc-c++ redhat-rpm-config redhat-release which xz sed make bzip2 gzip gcc coreutils unzip shadow-utils diffutils cpio bash gawk rpm-build info patch util-linux findutils grep'
config_opts['dist'] = 'el8'  # only useful for --resultdir variable subst
config_opts['releasever'] = '8'
config_opts['macros']['%dist'] = '.el8'
config_opts['package_manager'] = 'dnf'
config_opts['description'] = 'Elastifile Rocky Linux 8'
config_opts['rpmbuild_networking'] = True
config_opts['use_bootstrap'] = False
config_opts['use_host_resolv'] = True

config_opts['dnf.conf'] = """
[main]
keepcache=1
debuglevel=2
reposdir=/dev/null
logfile=/var/log/yum.log
retries=20
obsoletes=1
gpgcheck=0
assumeyes=1
syslog_ident=mock
syslog_device=
metadata_expire=0
mdpolicy=group:primary
best=1
install_weak_deps=0
protected_packages=
module_platform_id=platform:el8
user_agent={{ user_agent }}
